### PR TITLE
Make stretch filter apply only to oblique level

### DIFF
--- a/project/scenes/game_state.gd
+++ b/project/scenes/game_state.gd
@@ -5,6 +5,7 @@ extends Node
 @onready var _pause_menu_system: PauseMenuSystem = %PauseMenuSystem
 @onready var _replay_system: ReplaySystem = %ReplaySystem
 @onready var player_input: PlayerInput = %PlayerInput
+@onready var stretch_filter: CanvasLayer = %StretchFilter
 
 # Public Methods
 
@@ -20,6 +21,7 @@ func _ready() -> void:
 	assert(_pause_menu_system)
 	assert(_replay_system)
 	assert(player_input)
+	assert(stretch_filter)
 
 	util.printdbg("DEBUG BUILD")
 

--- a/project/scenes/game_state.tscn
+++ b/project/scenes/game_state.tscn
@@ -10,6 +10,7 @@
 [ext_resource type="Script" uid="uid://btc74n06ykolu" path="res://scripts/systems/system_dialog.gd" id="6_rxqo8"]
 [ext_resource type="Shader" uid="uid://cucunjhgkuj2r" path="res://shaders/palette-post.gdshader" id="7_q5byu"]
 [ext_resource type="Shader" uid="uid://ctckeik4qa432" path="res://shaders/dither-post.gdshader" id="8_vsyf1"]
+[ext_resource type="Script" uid="uid://rv011aypji1s" path="res://scenes/stretch_filter.gd" id="9_hinck"]
 [ext_resource type="Shader" uid="uid://b6r0sgv5nhjac" path="res://shaders/stretch-post.gdshader" id="9_ou381"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_3oy0g"]
@@ -70,7 +71,6 @@ metadata/_custom_type_script = "uid://btc74n06ykolu"
 visible = false
 
 [node name="DitherFilter" type="ColorRect" parent="DitherFilter" unique_id=1046001627]
-unique_name_in_owner = true
 material = SubResource("ShaderMaterial_3oy0g")
 anchors_preset = 15
 anchor_right = 1.0
@@ -80,6 +80,8 @@ grow_vertical = 2
 mouse_filter = 2
 
 [node name="StretchFilter" type="CanvasLayer" parent="." unique_id=1734074323]
+unique_name_in_owner = true
+script = ExtResource("9_hinck")
 
 [node name="StretchFilter" type="ColorRect" parent="StretchFilter" unique_id=1814341450]
 material = SubResource("ShaderMaterial_hinck")

--- a/project/scenes/levels/mouselook/components/enable_stretch_filter.gd.gd
+++ b/project/scenes/levels/mouselook/components/enable_stretch_filter.gd.gd
@@ -1,0 +1,6 @@
+class_name EnableStretchFilter
+extends Node
+
+func _ready() -> void:
+	gamestate.stretch_filter.show()
+	queue_free()

--- a/project/scenes/levels/mouselook/components/enable_stretch_filter.gd.gd.uid
+++ b/project/scenes/levels/mouselook/components/enable_stretch_filter.gd.gd.uid
@@ -1,0 +1,1 @@
+uid://bc734u7brvf46

--- a/project/scenes/levels/obliquetile/oblique_player.tscn
+++ b/project/scenes/levels/obliquetile/oblique_player.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="SpriteFrames" uid="uid://8sbpwgy03j5q" path="res://assets/spritesheets/littleguy_frames.tres" id="1_htjmx"]
 [ext_resource type="Script" uid="uid://b6mo6yr28xmfn" path="res://scripts/components/fancy_sprite_3d.gd" id="2_27wc5"]
 
-[node name="Player" type="Node3D" unique_id=1920999902]
+[node name="ObliquePlayer" type="Node3D" unique_id=1920999902]
 
 [node name="FancySprite3D" type="AnimatedSprite3D" parent="." unique_id=258600184]
 flip_h = true

--- a/project/scenes/levels/obliquetile/oblique_tile_level.tscn
+++ b/project/scenes/levels/obliquetile/oblique_tile_level.tscn
@@ -1,8 +1,9 @@
 [gd_scene format=3 uid="uid://lmp14m6v5wf4"]
 
 [ext_resource type="MeshLibrary" uid="uid://q2vjmi8n4ipj" path="res://assets/meshlibrary/test.meshlib" id="1_7367b"]
+[ext_resource type="Script" uid="uid://bc734u7brvf46" path="res://scenes/levels/mouselook/components/enable_stretch_filter.gd.gd" id="1_bwg66"]
 [ext_resource type="Script" uid="uid://dgpbhxs8ofy5g" path="res://scenes/levels/mouselook/components/remove_on_game_start.gd" id="2_bwg66"]
-[ext_resource type="PackedScene" uid="uid://bwcxyj2dueo8r" path="res://scenes/levels/obliquetile/player.tscn" id="2_ycx6c"]
+[ext_resource type="PackedScene" uid="uid://bwcxyj2dueo8r" path="res://scenes/levels/obliquetile/oblique_player.tscn" id="2_ycx6c"]
 
 [sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_6f4l4"]
 
@@ -20,6 +21,10 @@ ambient_light_color = Color(0.796243, 0.796243, 0.796243, 1)
 [sub_resource type="SphereMesh" id="SphereMesh_ppqqn"]
 
 [node name="ObliqueTileLevel" type="Node3D" unique_id=919855827]
+
+[node name="EnableStretchFilter" type="Node" parent="." unique_id=1659594320]
+script = ExtResource("1_bwg66")
+metadata/_custom_type_script = "uid://bc734u7brvf46"
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="." unique_id=1232387666]
 environment = SubResource("Environment_vmmfd")
@@ -57,5 +62,5 @@ shape = SubResource("SphereShape3D_vmmfd")
 [node name="MeshInstance3D" type="MeshInstance3D" parent="RigidBody3D" unique_id=439081567]
 mesh = SubResource("SphereMesh_ppqqn")
 
-[node name="Player" parent="." unique_id=1920999902 instance=ExtResource("2_ycx6c")]
+[node name="ObliquePlayer" parent="." unique_id=1920999902 instance=ExtResource("2_ycx6c")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 1.3909116, 1.1888564, 0)

--- a/project/scenes/stretch_filter.gd
+++ b/project/scenes/stretch_filter.gd
@@ -1,0 +1,4 @@
+extends CanvasLayer
+
+func _ready() -> void:
+	visible = false

--- a/project/scenes/stretch_filter.gd.uid
+++ b/project/scenes/stretch_filter.gd.uid
@@ -1,0 +1,1 @@
+uid://rv011aypji1s


### PR DESCRIPTION
Fix stretch filter applying to all levels, instead of just oblique tile level