### PR TITLE
Add workaround to autoload type bug

### DIFF
--- a/project/autoload/overlay/main_menu_handler.gd
+++ b/project/autoload/overlay/main_menu_handler.gd
@@ -17,15 +17,15 @@ func _quit() -> void:
 
 
 func _save_game_dialog() -> void:
-	var filename: String = await overlay.system_dialog.file_save_dialog("*.sav", "Save File")
+	var filename: String = await overlay.n.system_dialog.file_save_dialog("*.sav", "Save File")
 	if filename:
-		util.a_ok(overlay.save_state.save_to_file(filename))
+		util.a_ok(overlay.n.save_state.save_to_file(filename))
 
 
 func _load_game_dialog() -> void:
-	var filename: String = await overlay.system_dialog.file_open_dialog("*.sav", "Save File")
+	var filename: String = await overlay.n.system_dialog.file_open_dialog("*.sav", "Save File")
 	if filename:
-		var err: Error = overlay.save_state.load_from_file(filename)
+		var err: Error = overlay.n.save_state.load_from_file(filename)
 		assert(not err)
 
 

--- a/project/autoload/overlay/overlay.gd
+++ b/project/autoload/overlay/overlay.gd
@@ -1,3 +1,4 @@
+class_name AutoloadOverlay
 extends Node
 
 @export var _test_cycle_scenes: Array[PackedScene] = []

--- a/project/autoload/overlay_wrapper.gd
+++ b/project/autoload/overlay_wrapper.gd
@@ -1,0 +1,7 @@
+extends Node
+
+# Godot bug: Autoloaded scenes do not have type information.
+# This class is a workaround until fix is merged:
+# https://github.com/godotengine/godot/pull/98313
+
+var n: AutoloadOverlay = overlay_

--- a/project/autoload/overlay_wrapper.gd.uid
+++ b/project/autoload/overlay_wrapper.gd.uid
@@ -1,0 +1,1 @@
+uid://tytxrswba3pu

--- a/project/common/components/persist_group.gd
+++ b/project/common/components/persist_group.gd
@@ -74,4 +74,4 @@ func _ready() -> void:
 			_nodes.push_back(node)
 			assert(_keys.size() == _nodes.size())
 
-	overlay.sync_object_state(unique_state_key, self)
+	overlay.n.sync_object_state(unique_state_key, self)

--- a/project/project.godot
+++ b/project/project.godot
@@ -20,7 +20,8 @@ config/icon="res://icon.svg"
 
 constants="*uid://kyebjiac1qqb"
 signalbus="*uid://b2mmgrdlgnuf7"
-overlay="*res://autoload/overlay/overlay.tscn"
+overlay_="*res://autoload/overlay/overlay.tscn"
+overlay="*uid://tytxrswba3pu"
 gamestate="*uid://cp8fyt7psjvop"
 reinput="*uid://cckj6in5i8to3"
 

--- a/project/systems/dialogue_system/dialogue_entry.gd
+++ b/project/systems/dialogue_system/dialogue_entry.gd
@@ -45,7 +45,7 @@ func start() -> void:
 		stop()
 
 	_current_event_key = entry_name
-	util.a_ok(overlay.dialogue_layer.advanced.connect(_on_advance))
+	util.a_ok(overlay.n.dialogue_layer.advanced.connect(_on_advance))
 	signalbus.dialogue_started.emit()
 	_start_next_event()
 
@@ -126,7 +126,7 @@ func _start_next_event() -> void:
 			_current_choices.push_back(choice)
 			util.a_false(choice_texts.push_back(choice.text))
 
-	overlay.dialogue_layer.render(speaker, text, choice_texts)
+	overlay.n.dialogue_layer.render(speaker, text, choice_texts)
 
 
 func _render_sequence_entry() -> void:
@@ -136,7 +136,7 @@ func _render_sequence_entry() -> void:
 	for line in entry.text:
 		text.push_back(_interpolate(line))
 	var no_choices: PackedStringArray = []
-	overlay.dialogue_layer.render(entry.speaker, text, no_choices)
+	overlay.n.dialogue_layer.render(entry.speaker, text, no_choices)
 
 
 func _on_advance(index: int) -> void:
@@ -195,7 +195,7 @@ func _call_callback(callback: DialogueEvent.DialogueCallback) -> void:
 
 
 func stop() -> void:
-	overlay.dialogue_layer.advanced.disconnect(_on_advance)
-	overlay.dialogue_layer.hide()
+	overlay.n.dialogue_layer.advanced.disconnect(_on_advance)
+	overlay.n.dialogue_layer.hide()
 	signalbus.dialogue_ended.emit()
 	_current_event_key = ""


### PR DESCRIPTION
Workaround for: https://github.com/godotengine/godot/pull/98313

- Adds an autoloaded "overlay" wrapper script with a type-safe accessor to the actual autoloaded overlay scene.
- Replaces `overlay` with `overlay.n` (node) in scripts
- After change, no more warnings in "Debugger" tab